### PR TITLE
Update menu.js

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -98,25 +98,29 @@ function OpenMenu( elm ) {
 }
 function CloseMenu( elm, force ) {
 
-	// Ensure elm is targeted on the haspopup element
-	if ( !elm.hasAttribute( "aria-haspopup" ) ) {
-		elm = elm.previousElementSibling;
-	}
+	//Ensure elm isn't null
+	if ( elm ) {
 
-	if ( !force ) {
-
-		// Can the menu be closed?
-		// Get the menu item that has the focus.
-		var currentFocusIsOn = elm.nextElementSibling.querySelector( "[role=menuitem]:focus" );
-		var siblingHasFocus = elm.parentElement.parentElement.querySelector( "[role=menuitem]:focus" );
-
-		// Check if we keep the menu opon
-		if ( currentFocusIsOn || siblingHasFocus === elm ) {
-			return;
+		// Ensure elm is targeted on the haspopup element
+		if ( !elm.hasAttribute( "aria-haspopup" ) ) {
+			elm = elm.previousElementSibling;
 		}
-	}
 
-	elm.setAttribute( "aria-expanded", "false" );
+		if ( !force ) {
+
+			// Can the menu be closed?
+			// Get the menu item that has the focus.
+			var currentFocusIsOn = elm.nextElementSibling.querySelector( "[role=menuitem]:focus" );
+			var siblingHasFocus = elm.parentElement.parentElement.querySelector( "[role=menuitem]:focus" );
+
+			// Check if we keep the menu opon
+			if ( currentFocusIsOn || siblingHasFocus === elm ) {
+				return;
+			}
+		}
+
+		elm.setAttribute( "aria-expanded", "false" );
+	}
 }
 
 // On hover, wait for the delay before to open the menu


### PR DESCRIPTION
Fix https://gccode.ssc-spc.gc.ca/iitb-dgiit/nw-ws/sgdc-cdts/issues/109
Esc Key doesn't work in Leaving a secure session

Problem is that elm is null
Francis Wrote:

Avant : 
// Add menu navigation instruction
subElm.previousElementSibling.setAttribute( "aria-label", i18nInstruction );

Après :
// Add menu navigation instruction
If ( subElm ) {
subElm.previousElementSibling.setAttribute( "aria-label", i18nInstruction );
}

Mais idéalement effectivement le problème est cause par le fait qu’il n’y a pas le menu de GCWeb, alors il faudrait faire quelque chose avec ça.


